### PR TITLE
Miscellaneous PEP8 and minor changes

### DIFF
--- a/pyspeedtest.py
+++ b/pyspeedtest.py
@@ -365,6 +365,7 @@ def main(args=None):
             logging.exception(e)
         else:
             logging.error(e)
+        sys.exit(1)
 
 
 def pretty_speed(speed):

--- a/pyspeedtest.py
+++ b/pyspeedtest.py
@@ -196,8 +196,9 @@ class SpeedTest(object):
             logging.info('Failed to retrieve coordinates')
             return None
         location = match.groups()
-        logging.info('Your IP: %s\nYour latitude: %s\nYour longitude: %s' %
-                     location)
+        logging.info('Your IP: %s', location[0])
+        logging.info('Your latitude: %s', location[1])
+        logging.info('Your longitude: %s', location[2])
         connection.request(
             'GET', '/speedtest-servers.php?x=%d' % now, None, extra_headers)
         response = connection.getresponse()

--- a/pyspeedtest.py
+++ b/pyspeedtest.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 
 import argparse
 import bisect
+import itertools
 import logging
 import random
 import re
@@ -121,13 +122,9 @@ class SpeedTest(object):
             self.connect(self.host) for i in range(self.runs)
         ]
 
-        post_data = []
-        for current_file_size in SpeedTest.UPLOAD_FILES:
-            values = {
-                'content0': ''.join(
-                    random.choice(SpeedTest.ALPHABET) for i in range(current_file_size))
-            }
-            post_data.append(urlencode(values))
+        post_data = [
+            urlencode({'content0': content(s)}) for s in SpeedTest.UPLOAD_FILES
+        ]
 
         total_uploaded = 0
         total_start_time = time()
@@ -228,6 +225,12 @@ class SpeedTest(object):
             raise Exception('Cannot find a test server')
         LOG.debug('Best server: %s', best_server[1])
         return best_server[1]
+
+
+def content(length):
+    """Return alphanumeric string of indicated length."""
+    cycle = itertools.cycle(SpeedTest.ALPHABET)
+    return ''.join(next(cycle) for i in range(length))
 
 
 def init_logging(loglevel=logging.WARNING):

--- a/pyspeedtest.py
+++ b/pyspeedtest.py
@@ -6,7 +6,6 @@ from __future__ import print_function
 import argparse
 import bisect
 import logging
-import os
 import random
 import re
 import string
@@ -27,7 +26,6 @@ except ImportError:
     from urllib.parse import urlencode
 
 __program__ = 'pyspeedtest'
-__script__ = os.path.basename(sys.argv[0])
 __version__ = '1.2.5'
 __description__ = 'Test your bandwidth speed using Speedtest.net servers.'
 

--- a/pyspeedtest.py
+++ b/pyspeedtest.py
@@ -79,9 +79,9 @@ class SpeedTest(object):
 
     def download(self):
         total_downloaded = 0
-        connections = []
-        for run in range(self.runs):
-            connections.append(self.connect(self.host))
+        connections = [
+            self.connect(self.host) for i in range(self.runs)
+        ]
         total_start_time = time()
         for current_file in SpeedTest.DOWNLOAD_FILES:
             threads = []
@@ -117,9 +117,9 @@ class SpeedTest(object):
         self_thread.uploaded = int(reply.split('=')[1])
 
     def upload(self):
-        connections = []
-        for run in range(self.runs):
-            connections.append(self.connect(self.host))
+        connections = [
+            self.connect(self.host) for i in range(self.runs)
+        ]
 
         post_data = []
         for current_file_size in SpeedTest.UPLOAD_FILES:

--- a/pyspeedtest.py
+++ b/pyspeedtest.py
@@ -354,7 +354,7 @@ def perform_speedtest(opts):
 def main(args=None):
     opts = parseargs(args)
     logging.basicConfig(
-        format='%(message)s',
+        format='%(levelname)s: %(message)s',
         level=logging.INFO if opts.verbose else logging.WARNING)
     try:
         perform_speedtest(opts)

--- a/pyspeedtest.py
+++ b/pyspeedtest.py
@@ -96,8 +96,8 @@ class SpeedTest(object):
             for thread in threads:
                 thread.join()
                 total_downloaded += thread.downloaded
-                logging.info('Run %d for %s finished',
-                             thread.run_number, current_file)
+                logging.debug('Run %d for %s finished',
+                              thread.run_number, current_file)
         total_ms = (time() - total_start_time) * 1000
         for connection in connections:
             connection.close()
@@ -141,8 +141,8 @@ class SpeedTest(object):
                 threads.append(thread)
             for thread in threads:
                 thread.join()
-                logging.info('Run %d for %d bytes finished',
-                             thread.run_number, thread.uploaded)
+                logging.debug('Run %d for %d bytes finished',
+                              thread.run_number, thread.uploaded)
                 total_uploaded += thread.uploaded
         total_ms = (time() - total_start_time) * 1000
         for connection in connections:
@@ -174,7 +174,7 @@ class SpeedTest(object):
         times.remove(worst)
         total_ms = sum(times) * 250  # * 1000 / number of tries (4) = 250
         connection.close()
-        logging.info('Latency for %s - %d', server, total_ms)
+        logging.debug('Latency for %s - %d', server, total_ms)
         return total_ms
 
     def chooseserver(self):
@@ -215,7 +215,7 @@ class SpeedTest(object):
             bisect.insort_left(sorted_server_list, (distance, server[0]))
         best_server = (999999, '')
         for server in sorted_server_list[:10]:
-            logging.info(server[1])
+            logging.debug(server[1])
             match = re.search(
                 r'http://([^/]+)/speedtest/upload\.php', server[1])
             if match is None:
@@ -356,7 +356,7 @@ def main(args=None):
     opts = parseargs(args)
     logging.basicConfig(
         format='%(levelname)s: %(message)s',
-        level=logging.INFO if opts.verbose else logging.WARNING)
+        level=logging.DEBUG if opts.verbose else logging.WARNING)
     try:
         perform_speedtest(opts)
     except Exception as e:

--- a/pyspeedtest.py
+++ b/pyspeedtest.py
@@ -69,7 +69,7 @@ class SpeedTest(object):
             connection.connect()
             return connection
         except:
-            raise Exception("Error connecting to '%s'" % url)
+            raise Exception("Unable to connect to '%s'" % url)
 
     def downloadthread(self, connection, url):
         connection.request('GET', url, None, {'Connection': 'Keep-Alive'})

--- a/pyspeedtest.py
+++ b/pyspeedtest.py
@@ -306,7 +306,7 @@ def parseargs(args):
     parser.add_argument(
         '--version',
         action='version',
-        version='{0} {1}'.format(__program__, __version__))
+        version='%(prog)s ' + __version__)
 
     return parser.parse_args(args)
 

--- a/pyspeedtest.py
+++ b/pyspeedtest.py
@@ -106,7 +106,7 @@ class SpeedTest(object):
         return total_downloaded * 8000 / total_ms
 
     def uploadthread(self, connection, data):
-        url = '/speedtest/upload.php?x=%s' % random.random()
+        url = '/speedtest/upload.php?x=%d' % randint()
         connection.request('POST', url, data, {
             'Connection': 'Keep-Alive',
             'Content-Type': 'application/x-www-form-urlencoded'
@@ -162,7 +162,7 @@ class SpeedTest(object):
             total_start_time = time()
             connection.request(
                 'GET',
-                '/speedtest/latency.txt?x=%d' % random.random(),
+                '/speedtest/latency.txt?x=%d' % randint(),
                 None,
                 {'Connection': 'Keep-Alive'})
             response = connection.getresponse()
@@ -373,6 +373,12 @@ def pretty_speed(speed):
         speed /= 1024
         unit += 1
     return '%0.2f %s' % (speed, units[unit])
+
+
+def randint():
+    """Return a random 12 digit integer."""
+    return random.randint(100000000000, 999999999999)
+
 
 if __name__ == '__main__':
     main()

--- a/pyspeedtest.py
+++ b/pyspeedtest.py
@@ -69,7 +69,7 @@ class SpeedTest(object):
             connection.connect()
             return connection
         except:
-            raise Exception("Unable to connect to '%s'" % url)
+            raise Exception('Unable to connect to %r' % url)
 
     def downloadthread(self, connection, url):
         connection.request('GET', url, None, {'Connection': 'Keep-Alive'})
@@ -247,12 +247,12 @@ def parseargs(args):
             return ivalue
         except ValueError:
             raise argparse.ArgumentTypeError(
-                "invalid positive int value: '%s'" % value)
+                'invalid positive int value: %r' % value)
 
     def format_enum(value):
         if value.lower() not in __supported_formats__:
             raise argparse.ArgumentTypeError(
-                "output format not supported: '%s'" % value)
+                'output format not supported: %r' % value)
         return value
 
     parser = argparse.ArgumentParser(

--- a/setup.py
+++ b/setup.py
@@ -41,8 +41,8 @@ setup(
     description='Speedtest.net Python script',
     long_description=README,
     url='https://github.com/fopina/pyspeedtest',
-    download_url='https://github.com/fopina/pyspeedtest/tarball/v%s'
-                % __version__,
+    download_url='https://github.com/fopina/pyspeedtest/tarball/v%s' %
+    __version__,
     author='Filipe Pina',
     author_email='fopina@skmobi.com',
     py_modules=['pyspeedtest'],

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
+
 import os
 import sys
 

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,12 @@
 # -*- coding: utf-8 -*-
 
 import os
-from setuptools import setup
-from pyspeedtest import __program__, __version__
 import sys
+
+from setuptools import setup
+
+from pyspeedtest import __program__, __version__
+
 
 if sys.argv[-1] == 'pub':
     import pypandoc  # quick check

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ if sys.argv[-1] == 'pubtest':
 try:
     import pypandoc
     README = pypandoc.convert(os.path.join(os.path.dirname(__file__), 'README.md'), 'rst')
-except(IOError, ImportError):		
+except(IOError, ImportError):
     README = open('README.md').read()
 
 if sys.argv[-1] == 'readmerst':

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ if sys.argv[-1] == 'pubtest':
 try:
     import pypandoc
     README = pypandoc.convert(os.path.join(os.path.dirname(__file__), 'README.md'), 'rst')
-except(IOError, ImportError):
+except (IOError, ImportError):
     README = open('README.md').read()
 
 if sys.argv[-1] == 'readmerst':

--- a/test.sh
+++ b/test.sh
@@ -9,6 +9,10 @@ set -e
 # enable xtrace
 set -x
 
+# pipeline's return status is the value of the last (rightmost) command to exit
+# with a non-zero status, or zero if all commands exit successfully
+set -o pipefail
+
 # package the project
 python setup.py sdist
 

--- a/test.sh
+++ b/test.sh
@@ -52,7 +52,7 @@ for format in default json xml; do
 done
 
 # test multiple arguments at once and verify output
-pyspeedtest --debug=0 --mode=7 --runs=2 |& grep -qE $'^Using server: .*\nDownload speed: [0-9.]+ (bps|Kbps|Mbps|Gbps)\nUpload speed: [0-9.]+ (bps|Kbps|Mbps|Gbps)$'
+pyspeedtest --debug=0 --mode=7 --runs=2 |& grep -qE $'^Using server: .*\nPing: [0-9]+ ms\nDownload speed: [0-9.]+ (bps|Kbps|Mbps|Gbps)\nUpload speed: [0-9.]+ (bps|Kbps|Mbps|Gbps)$'
 
 # test for bad arguments
 ! pyspeedtest -x


### PR DESCRIPTION
I have a few minor changes in case you're interested.
- PEP8 stuff (indentation, whitespace, unused objects, reorder imports)
- Logging messages are now output as follows (to differentiate between the various types of message):

> ERROR: Unable to connect to 'www.speedtest.net'
> INFO: Took 15559 ms to upload 1255152 bytes
- The program exits with an exit status of 1 upon error (like any other *nix program). Note use of `sys.exit(1)` rather than `exit(1)`. See https://bugs.python.org/issue8220.
- Also I noticed a prior screw-up of mine. `'%d' % random.random()` is `'0'`, which is obviously not the desired result. So that's been fixed and replaced with the creation of a random 12-digit integer.
- Fix for #7. Test for expected ping output and ensure pipeline exits successfully.
