### PR TITLE
Change server from www to c.speedtest.net

### DIFF
--- a/pyspeedtest.py
+++ b/pyspeedtest.py
@@ -183,7 +183,7 @@ class SpeedTest(object):
         return total_ms
 
     def chooseserver(self):
-        connection = self.connect('www.speedtest.net')
+        connection = self.connect('c.speedtest.net')
         now = int(time() * 1000)
         # really contribute to speedtest.net OS statistics
         # maybe they won't block us again...


### PR DESCRIPTION
as it is much more stable.
Currently, www.speedtest.net does not always work- actually- most of the times it doesn't and I just get 
'Cannot find a test server'

My code is:
st = pyspeedtest.SpeedTest() try: ping = st.ping() download = st.download() upload = st.upload() except Exception as e: logger.warning(f'speed test failure. {e}')